### PR TITLE
Change rangeStrategy back to "auto"

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,5 @@
 {
   "extends": ["config:base"],
-  "rangeStrategy": "bump",
   "automerge": false,
   "major": {
     "automerge": false


### PR DESCRIPTION
`bump` was not appropriate when it comes to handle `peerDependencies`. Looking through the official doc, https://renovatebot.com/docs/configuration-options/#rangestrategy, I found that the default strategy is good enough to adopt in this project.