### PR TITLE
Fix an issue where rule was not correctly exported

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,9 @@
-export { default, ruleName, messages } from './stylelint-no-unused-selectors';
+import {
+  default as rule,
+  ruleName,
+  messages,
+} from './stylelint-no-unused-selectors';
+
+module.exports = rule;
+module.exports.ruleName = ruleName;
+module.exports.messages = messages;


### PR DESCRIPTION
The rule should be exported directly under `module.exports`, but it was exported as `default`, which was equivalent to `module.exports.default`.