### PR TITLE
Rename parser to plugin

### DIFF
--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -2,29 +2,29 @@ import path from 'path';
 import { Undefinable } from 'option-t/lib/Undefinable';
 import PostcssSelectorParser from 'postcss-selector-parser';
 
-import { HTMLParser } from './parsers/html';
-import { JSXParser } from './parsers/jsx';
-import { TSXParser } from './parsers/tsx';
+import { HTMLPlugin } from './plugins/html';
+import { JSXPlugin } from './plugins/jsx';
+import { TSXPlugin } from './plugins/tsx';
 
-export interface Parser {
+export interface Plugin {
   parse(document: string): void | Promise<void>;
   match(selectorAst: PostcssSelectorParser.Root): boolean | Promise<boolean>;
 }
 
-export function createParser(docPath: string): Undefinable<Parser> {
+export function getPlugin(docPath: string): Undefinable<Plugin> {
   const ext = path.extname(docPath);
 
   switch (ext) {
     case '.html':
     case '.htm':
-      return new HTMLParser();
+      return new HTMLPlugin();
 
     case '.jsx':
     case '.js':
-      return new JSXParser();
+      return new JSXPlugin();
 
     case '.tsx':
-      return new TSXParser();
+      return new TSXPlugin();
 
     default:
       return undefined;

--- a/src/plugins/html.ts
+++ b/src/plugins/html.ts
@@ -2,9 +2,9 @@ import { JSDOM } from 'jsdom';
 import { Undefinable } from 'option-t/lib/Undefinable';
 import PostcssSelectorParser from 'postcss-selector-parser';
 
-import { Parser } from '../parser';
+import { Plugin } from '../plugin';
 
-export class HTMLParser implements Parser {
+export class HTMLPlugin implements Plugin {
   private _dom: Undefinable<JSDOM>;
 
   public constructor() {

--- a/src/plugins/jsx.ts
+++ b/src/plugins/jsx.ts
@@ -20,7 +20,7 @@ import PostcssSelectorParser from 'postcss-selector-parser';
 // @ts-ignore
 import removeFlowTypes from 'flow-remove-types';
 
-import { Parser } from '../parser';
+import { Plugin } from '../plugin';
 import { jsxWalker } from '../utils/acorn-jsx-walker';
 import { isSimpleSelector } from '../utils/is-simple-selector';
 
@@ -281,7 +281,7 @@ function extractClassesAndIds(ast: Node): { classes: string[]; ids: string[] } {
   return { classes, ids };
 }
 
-export class JSXParser implements Parser {
+export class JSXPlugin implements Plugin {
   private _ast: Undefinable<Node>;
   private _classes: string[];
   private _ids: string[];

--- a/src/plugins/tsx.ts
+++ b/src/plugins/tsx.ts
@@ -4,7 +4,7 @@ import { unwrapUndefinable } from 'option-t/lib/Undefinable/unwrap';
 import { andThenForUndefinable } from 'option-t/lib/Undefinable/andThen';
 import PostcssSelectorParser from 'postcss-selector-parser';
 
-import { Parser } from '../parser';
+import { Plugin } from '../plugin';
 import { isSimpleSelector } from '../utils/is-simple-selector';
 
 function extractAttributeValue(node: ts.JsxAttribute): Undefinable<string> {
@@ -324,7 +324,7 @@ function extractClassesAndIds(
   return { classes, ids };
 }
 
-export class TSXParser implements Parser {
+export class TSXPlugin implements Plugin {
   private _ast: Undefinable<ts.SourceFile>;
   private _classes: string[];
   private _ids: string[];

--- a/src/stylelint-no-unused-selectors.ts
+++ b/src/stylelint-no-unused-selectors.ts
@@ -11,7 +11,7 @@ import { Root, Result } from 'postcss';
 import resolveNestedSelector from 'postcss-resolve-nested-selector';
 import createSelectorProcessor from 'postcss-selector-parser';
 
-import { createParser } from './parser';
+import { getPlugin } from './plugin';
 
 import { DeepPartial } from './types/deep-partial';
 import { resolveDocuments, resolveDocument } from './utils/document-resolver';
@@ -102,13 +102,13 @@ function rule(
     }
 
     const { path: documentPath, document } = resolution;
-    const parser = createParser(documentPath);
+    const plugin = getPlugin(documentPath);
 
-    if (!parser) {
+    if (!plugin) {
       return;
     }
 
-    await parser.parse(document);
+    await plugin.parse(document);
 
     root.walkRules(
       async (rule): Promise<void> => {
@@ -124,7 +124,7 @@ function rule(
         async function processSelector(selector: string): Promise<void> {
           const selectorAst = await selectorProcessor.ast(selector);
           const filteredAst = removeUnassertiveSelector(selectorAst);
-          const matched = await unwrapUndefinable(parser).match(filteredAst);
+          const matched = await unwrapUndefinable(plugin).match(filteredAst);
 
           if (!matched) {
             stylelint.utils.report({


### PR DESCRIPTION
Since our "parser" has two methods, _parse_ and _match_, its name doesn't fully represent its usage and responsibilities.