### PR TITLE
Fix an issue where dist directory was not included in the published package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,1 +1,0 @@
-*.tsbuildinfo

--- a/package.json
+++ b/package.json
@@ -13,9 +13,7 @@
     "stylelint-plugin"
   ],
   "files": [
-    "README.md",
-    "package.json",
-    "dist"
+    "dist/**/*"
   ],
   "scripts": {
     "clean": "rimraf dist",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stylelint-no-unused-selectors",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "A rule for stylelint to disallow unused selectors",
   "main": "dist/index.js",
   "repository": "https://github.com/nodaguti/stylelint-no-unused-selectors",

--- a/package.json
+++ b/package.json
@@ -16,15 +16,15 @@
     "dist/**/*"
   ],
   "scripts": {
-    "clean": "rimraf dist",
-    "build": "yarn clean && tsc --project ./tsconfig.json --outDir dist",
+    "clean": "rimraf dist .tsbuildinfo",
+    "build": "tsc --project ./tsconfig.json --outDir dist",
     "lint": "tsc --project ./tsconfig.json --noEmit && eslint --cache 'src/**/*.{ts,js}'",
     "fmt": "prettier --write *.{ts,js,json,md} src/**/*.{ts,js,json,md}",
     "check_fmt": "yarn fmt && git diff --exit-code",
     "test": "jest",
-    "publish:patch": "yarn build && npm version patch && git push origin HEAD && git push origin --tags && npm publish --access=public",
-    "publish:minor": "yarn build && npm version minor && git push origin HEAD && git push origin --tags && npm publish --access=public",
-    "publish:major": "yarn build && npm version major && git push origin HEAD && git push origin --tags && npm publish --access=public"
+    "publish:patch": "yarn clean && yarn build && npm version patch && git push origin HEAD && git push origin --tags && npm publish --access=public",
+    "publish:minor": "yarn clean && yarn build && npm version minor && git push origin HEAD && git push origin --tags && npm publish --access=public",
+    "publish:major": "yarn clean && yarn build && npm version major && git push origin HEAD && git push origin --tags && npm publish --access=public"
   },
   "husky": {
     "hooks": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stylelint-no-unused-selectors",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "A rule for stylelint to disallow unused selectors",
   "main": "dist/index.js",
   "repository": "https://github.com/nodaguti/stylelint-no-unused-selectors",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stylelint-no-unused-selectors",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "A rule for stylelint to disallow unused selectors",
   "main": "dist/index.js",
   "repository": "https://github.com/nodaguti/stylelint-no-unused-selectors",


### PR DESCRIPTION
The root cause was cleaning the dist directory before building the project while .tsbuildinfo remained undeleted.
_I published several versions to figure out this... :P_