### PR TITLE
Update configuration format

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,42 +65,45 @@ The default configuration is:
 ```json
 {
   "rules": {
-    "plugin/no-unused-selectors": {
-      "resolve": {
-        "documents": [
-          "{cssDir}/{cssName}.tsx",
-          "{cssDir}/{cssName}.jsx",
-          "{cssDir}/{cssName}.html",
-          "{cssDir}/{cssName}.htm",
-          "{cssDir}/{cssDirName}.tsx",
-          "{cssDir}/{cssDirName}.jsx",
-          "{cssDir}/{cssDirName}.html",
-          "{cssDir}/{cssDirName}.htm",
-          "{cssDir}/index.tsx",
-          "{cssDir}/index.jsx",
-          "{cssDir}/index.html",
-          "{cssDir}/index.htm"
-        ]
-      },
-      "plugins": [
-        {
-          "test": "\\.html?$",
-          "plugin": "stylelint-no-unused-selectors-plugin-html"
+    "plugin/no-unused-selectors": [
+      true,
+      {
+        "resolve": {
+          "documents": [
+            "{cssDir}/{cssName}.tsx",
+            "{cssDir}/{cssName}.jsx",
+            "{cssDir}/{cssName}.html",
+            "{cssDir}/{cssName}.htm",
+            "{cssDir}/{cssDirName}.tsx",
+            "{cssDir}/{cssDirName}.jsx",
+            "{cssDir}/{cssDirName}.html",
+            "{cssDir}/{cssDirName}.htm",
+            "{cssDir}/index.tsx",
+            "{cssDir}/index.jsx",
+            "{cssDir}/index.html",
+            "{cssDir}/index.htm"
+          ]
         },
-        {
-          "test": "\\.jsx?$",
-          "plugin": "stylelint-no-unused-selectors-plugin-jsx",
-          "options": {
-            "sourceType": "module",
-            "plugins": ["jsx", "flow"]
+        "plugins": [
+          {
+            "test": "\\.html?$",
+            "plugin": "stylelint-no-unused-selectors-plugin-html"
+          },
+          {
+            "test": "\\.jsx?$",
+            "plugin": "stylelint-no-unused-selectors-plugin-jsx",
+            "options": {
+              "sourceType": "module",
+              "plugins": ["jsx", "flow"]
+            }
+          },
+          {
+            "test": "\\.tsx$",
+            "plugin": "stylelint-no-unused-selectors-plugin-tsx"
           }
-        },
-        {
-          "test": "\\.tsx$",
-          "plugin": "stylelint-no-unused-selectors-plugin-tsx"
-        }
-      ]
-    }
+        ]
+      }
+    ]
   }
 }
 ```

--- a/src/__tests__/parser-options.spec.ts
+++ b/src/__tests__/parser-options.spec.ts
@@ -1,30 +1,34 @@
 import path from 'path';
-import stylelint from 'stylelint';
+import stylelint, { Configuration } from 'stylelint';
 
 const fixturesRoot = path.join(__dirname, '..', '..', 'examples', 'jsx');
-const config = {
+
+const createConfig = (isEnabled = true): Partial<Configuration> => ({
   plugins: [path.join(__dirname, '..', '..', 'dist', 'index.js')],
   rules: {
-    'plugin/no-unused-selectors': {
-      plugins: [
-        {
-          test: '\\.jsx?$',
-          plugin: 'stylelint-no-unused-selectors-plugin-jsx',
-          options: {
-            sourceType: 'module',
-            plugins: [],
+    'plugin/no-unused-selectors': [
+      isEnabled,
+      {
+        plugins: [
+          {
+            test: '\\.jsx?$',
+            plugin: 'stylelint-no-unused-selectors-plugin-jsx',
+            options: {
+              sourceType: 'module',
+              plugins: [],
+            },
           },
-        },
-      ],
-    },
+        ],
+      },
+    ],
   },
-};
+});
 
 test('Throws a parse error when plugins in the @babel/parser options are left empty and a jsx file is tried to be linted', async (): Promise<
   void
 > => {
   const options = {
-    config,
+    config: createConfig(),
     files: path.join(fixturesRoot, '*.css'),
   };
 
@@ -38,4 +42,15 @@ test('Throws a parse error when plugins in the @babel/parser options are left em
     expect(err).toBeInstanceOf(Error);
     expect((err as Error).message).toMatch('Unexpected token');
   }
+});
+
+test('Does nothing if rule is disabled', async (): Promise<void> => {
+  const options = {
+    config: createConfig(false),
+    files: path.join(fixturesRoot, '*.css'),
+  };
+
+  const result = await stylelint.lint(options);
+
+  expect(result.errored).toBe(false);
 });

--- a/src/options.ts
+++ b/src/options.ts
@@ -17,10 +17,19 @@ export interface Options {
   plugins: PluginSetting[];
 }
 
+const isResolveObject = (
+  o: unknown,
+): o is {
+  documents: unknown;
+} => {
+  return Object.prototype.hasOwnProperty.call(o, 'documents');
+};
+
 const optionsSchema = {
-  resolve: {
-    documents: [(a: unknown): boolean => typeof a === 'string'],
-  },
+  resolve: (r: unknown): boolean =>
+    isResolveObject(r) &&
+    Array.isArray(r.documents) &&
+    r.documents.every((item): boolean => typeof item === 'string'),
   plugins: [
     (p: unknown): boolean =>
       typeof p === 'object' && p !== null && 'test' in p && 'plugin' in p,

--- a/src/stylelint-no-unused-selectors.ts
+++ b/src/stylelint-no-unused-selectors.ts
@@ -34,10 +34,11 @@ function getCSSSource(root: Root): Undefinable<string> {
 }
 
 function rule(
-  options?: DeepPartial<Options> | boolean,
+  primaryOption: boolean,
+  secondaryOptionObject?: DeepPartial<Options>,
 ): (root: Root, result: Result) => Promise<void> {
   return async (root, result): Promise<void> => {
-    if (options === false) {
+    if (primaryOption === false) {
       return;
     }
 
@@ -50,7 +51,7 @@ function rule(
     const opts = normaliseOptions(
       result,
       ruleName,
-      typeof options === 'object' ? options : {},
+      typeof secondaryOptionObject === 'object' ? secondaryOptionObject : {},
     );
 
     if (!opts) {


### PR DESCRIPTION
Hi! Thanks for the package!

The PR is intended to solve this issue: https://github.com/nodaguti/stylelint-no-unused-selectors/issues/128

1. The configuration object is now the configuration array (most rules use this format).
2. `optionsSchema` (the real root cause of the problem) has been updated.
